### PR TITLE
Permit Improvements

### DIFF
--- a/src/extensions/access_control/permit/index.ts
+++ b/src/extensions/access_control/permit/index.ts
@@ -67,15 +67,22 @@ const parsePermit = (savedPermit: string): Permit => {
 export const getPermit = async (
   contract: string,
   provider: SupportedProvider,
-): Promise<Permit> => {
+  autoGenerate: boolean = true
+): Promise<Permit | null> => {
   isAddress(contract);
   if (!provider) {
     throw new Error(`Missing provider`);
   }
 
+  const getSigner = determineRequestSigner(provider);
+  const signer = await getSigner(provider);
+
   let savedPermit = null;
   if (typeof window !== "undefined" && window.localStorage) {
-    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
+    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${await signer.getAddress()}`);
+    if (!savedPermit) { // Backward compatibility
+      savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
+    }
   }
 
   if (savedPermit) {
@@ -85,7 +92,7 @@ export const getPermit = async (
       console.warn(err);
     }
   }
-  return generatePermit(contract, provider);
+  return autoGenerate ? generatePermit(contract, provider) : null;
 };
 
 export const getAllPermits = (): Map<string, Permit> => {
@@ -95,6 +102,17 @@ export const getAllPermits = (): Map<string, Permit> => {
     const key = window.localStorage.key(i);
     if (key && key.includes(PERMIT_PREFIX)) {
       const contract = key.replace(PERMIT_PREFIX, "");
+      
+      // Not sure if needed, code placeholder:
+      // const noPrefixPermit = key.replace(PERMIT_PREFIX, "");
+      // let contract = "";
+      // if (noPrefixPermit.includes("_")) {
+      //   const tmp = noPrefixPermit.split("_");
+      //   contract = tmp[0];
+      // } else {
+      //   contract = noPrefixPermit;
+      // }
+      
       try {
         const permit = parsePermit(window.localStorage.getItem(key)!);
         permits.set(contract, permit);
@@ -108,9 +126,11 @@ export const getAllPermits = (): Map<string, Permit> => {
 
 interface SignerPublicSignedTypedData {
   signTypedData(domain: object, types: object, value: object): Promise<string>;
+  getAddress(): Promise<string>;
 }
 interface SignerPrivateSignedTypedData {
   _signTypedData(domain: object, types: object, value: object): Promise<string>;
+  getAddress(): Promise<string>;
 }
 
 export type PermitSigner =
@@ -218,23 +238,33 @@ export const generatePermit = async (
     };
 
     window.localStorage.setItem(
-      `${PERMIT_PREFIX}${contract}`,
+      `${PERMIT_PREFIX}${contract}_${await signer.getAddress()}`,
       JSON.stringify(serialized),
     );
   }
   return permit;
 };
 
-export const removePermit = (contract: string): void => {
-  window.localStorage.removeItem(`${PERMIT_PREFIX}${contract}`);
+export const removePermit = (contract: string, account: string): void => {
+  if (!account) { // Backward compatibility
+    window.localStorage.removeItem(`${PERMIT_PREFIX}${contract}`);
+  } else {
+    window.localStorage.removeItem(`${PERMIT_PREFIX}${contract}_${account}`);
+  }
 };
 
 export const getPermitFromLocalstorage = (
   contract: string,
+  account: string
 ): Permit | undefined => {
   let savedPermit = undefined;
   if (typeof window !== "undefined" && window.localStorage) {
-    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
+    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${account}`);
+    if (!account) { // Backward compatibility
+      savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
+    } else {
+      savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${account}`);
+    }
   }
 
   if (!savedPermit) {

--- a/src/extensions/access_control/permit/index.ts
+++ b/src/extensions/access_control/permit/index.ts
@@ -67,7 +67,7 @@ const parsePermit = (savedPermit: string): Permit => {
 export const getPermit = async (
   contract: string,
   provider: SupportedProvider,
-  autoGenerate: boolean = true
+  autoGenerate: boolean = true,
 ): Promise<Permit | null> => {
   isAddress(contract);
   if (!provider) {
@@ -79,8 +79,11 @@ export const getPermit = async (
 
   let savedPermit = null;
   if (typeof window !== "undefined" && window.localStorage) {
-    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${await signer.getAddress()}`);
-    if (!savedPermit) { // Backward compatibility
+    savedPermit = window.localStorage.getItem(
+      `${PERMIT_PREFIX}${contract}_${await signer.getAddress()}`,
+    );
+    if (!savedPermit) {
+      // Backward compatibility
       savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
     }
   }
@@ -102,7 +105,7 @@ export const getAllPermits = (): Map<string, Permit> => {
     const key = window.localStorage.key(i);
     if (key && key.includes(PERMIT_PREFIX)) {
       const contract = key.replace(PERMIT_PREFIX, "");
-      
+
       // Not sure if needed, code placeholder:
       // const noPrefixPermit = key.replace(PERMIT_PREFIX, "");
       // let contract = "";
@@ -112,7 +115,7 @@ export const getAllPermits = (): Map<string, Permit> => {
       // } else {
       //   contract = noPrefixPermit;
       // }
-      
+
       try {
         const permit = parsePermit(window.localStorage.getItem(key)!);
         permits.set(contract, permit);
@@ -246,7 +249,8 @@ export const generatePermit = async (
 };
 
 export const removePermit = (contract: string, account: string): void => {
-  if (!account) { // Backward compatibility
+  if (!account) {
+    // Backward compatibility
     window.localStorage.removeItem(`${PERMIT_PREFIX}${contract}`);
   } else {
     window.localStorage.removeItem(`${PERMIT_PREFIX}${contract}_${account}`);
@@ -255,15 +259,20 @@ export const removePermit = (contract: string, account: string): void => {
 
 export const getPermitFromLocalstorage = (
   contract: string,
-  account: string
+  account: string,
 ): Permit | undefined => {
   let savedPermit = undefined;
   if (typeof window !== "undefined" && window.localStorage) {
-    savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${account}`);
-    if (!account) { // Backward compatibility
+    savedPermit = window.localStorage.getItem(
+      `${PERMIT_PREFIX}${contract}_${account}`,
+    );
+    if (!account) {
+      // Backward compatibility
       savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}`);
     } else {
-      savedPermit = window.localStorage.getItem(`${PERMIT_PREFIX}${contract}_${account}`);
+      savedPermit = window.localStorage.getItem(
+        `${PERMIT_PREFIX}${contract}_${account}`,
+      );
     }
   }
 

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -301,10 +301,11 @@ export class FhenixClient {
   /**
    * Retrieves the stored permit for a specific contract address.
    * @param {string} contractAddress - The address of the contract.
+   * @param {string} account - The address of the user account.
    * @returns {Permit} - The permit associated with the contract address.
    */
-  getPermit(contractAddress: string): Permit | undefined {
-    const fromLs = getPermitFromLocalstorage(contractAddress);
+  getPermit(contractAddress: string, account: string): Permit | undefined {
+    const fromLs = getPermitFromLocalstorage(contractAddress, account);
     if (fromLs) {
       this.permits[contractAddress] = fromLs;
       return fromLs;

--- a/test/permit.test.ts
+++ b/test/permit.test.ts
@@ -83,6 +83,13 @@ describe("Permit Tests", () => {
     expect(cleartext).toBe(BigInt(value));
   });
 
+  it("try to load permit without auto generating a new one", async () => {
+    const provider = new MockProvider(tfhePublicKey);
+
+    const permit = await getPermit(contractAddress, provider, false);
+    expect(permit).toBe(null);    
+  });
+
   it("generates a permit and loads it to the instance", async () => {
     const provider = new MockProvider(tfhePublicKey);
     await expect(getPermit(undefined as any, provider)).rejects.toThrow(

--- a/test/permit.test.ts
+++ b/test/permit.test.ts
@@ -87,7 +87,7 @@ describe("Permit Tests", () => {
     const provider = new MockProvider(tfhePublicKey);
 
     const permit = await getPermit(contractAddress, provider, false);
-    expect(permit).toBe(null);    
+    expect(permit).toBe(null);
   });
 
   it("generates a permit and loads it to the instance", async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -35,6 +35,9 @@ export class MockSigner {
   async _signTypedData(domain: any, types: any, value: any): Promise<any> {
     return "0x123";
   }
+  async getAddress(): Promise<string> {
+    return "0x123456789";
+  }
 }
 
 export class MockProvider {


### PR DESCRIPTION
Add user account address to permit's key in local storage to support multiple accounts per contract.
Allow to get permit without generating a new one if it doesn't exists
