### PR TITLE
Security zones

### DIFF
--- a/src/sdk/encrypt.ts
+++ b/src/sdk/encrypt.ts
@@ -27,18 +27,20 @@ import { fromHexString, toBigInt } from "./utils";
  * Encrypts a Uint8 value using TFHE (Fast Fully Homomorphic Encryption over the Torus).
  * @param {boolean} value - The Boolean value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedBool} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_bool = (
   value: boolean,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedBool => {
   const encrypted = CompactFheBoolList.encrypt_with_compact_public_key(
     [value],
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -46,11 +48,13 @@ export const encrypt_bool = (
  * Encrypts a Uint8 value using TFHE (Fast Fully Homomorphic Encryption over the Torus).
  * @param {number} value - The Uint8 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint8} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint8 = (
   value: number,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint8 => {
   const uint8Array = new Uint8Array([value]);
   const encrypted = CompactFheUint8List.encrypt_with_compact_public_key(
@@ -58,7 +62,7 @@ export const encrypt_uint8 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -66,11 +70,13 @@ export const encrypt_uint8 = (
  * Encrypts a Uint16 value using TFHE.
  * @param {number} value - The Uint16 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint16} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint16 = (
   value: number,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint16 => {
   const uint16Array = new Uint16Array([value]);
   const encrypted = CompactFheUint16List.encrypt_with_compact_public_key(
@@ -78,7 +84,7 @@ export const encrypt_uint16 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -86,11 +92,13 @@ export const encrypt_uint16 = (
  * Encrypts a Uint32 value using TFHE.
  * @param {number} value - The Uint32 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint32} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint32 = (
   value: number,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint32 => {
   const uint32Array = new Uint32Array([value]);
   const encrypted = CompactFheUint32List.encrypt_with_compact_public_key(
@@ -98,7 +106,7 @@ export const encrypt_uint32 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -106,11 +114,13 @@ export const encrypt_uint32 = (
  * Encrypts a Uint64 value using TFHE.
  * @param {number} value - The Uint64 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint64} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint64 = (
   value: bigint | string,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint64 => {
   if (typeof value === "string") {
     value = toBigInt(fromHexString(value));
@@ -123,7 +133,7 @@ export const encrypt_uint64 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -131,11 +141,13 @@ export const encrypt_uint64 = (
  * Encrypts a Uint128 value using TFHE.
  * @param {bigint} value - The Uint128 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint128} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint128 = (
   value: bigint | string,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint128 => {
   if (typeof value === "string") {
     value = toBigInt(fromHexString(value));
@@ -148,7 +160,7 @@ export const encrypt_uint128 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 
@@ -156,11 +168,13 @@ export const encrypt_uint128 = (
  * Encrypts a Uint256 value using TFHE.
  * @param {bigint} value - The Uint256 value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {EncryptedUint256} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_uint256 = (
   value: bigint | string,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0,
 ): EncryptedUint256 => {
   if (typeof value === "string") {
     value = toBigInt(fromHexString(value));
@@ -173,18 +187,20 @@ export const encrypt_uint256 = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 /**
  * Encrypts a Address value using TFHE.
  * @param {bigint} value - The Address (Uint160) value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
+ * @param securityZone - The security zone to encrypt the address on.
  * @returns {EncryptedAddress} - The encrypted value serialized as Uint8Array.
  */
 export const encrypt_address = (
   value: bigint | string,
   publicKey: TfheCompactPublicKey,
+  securityZone: number = 0
 ): EncryptedAddress => {
   if (typeof value === "string") {
     value = toBigInt(fromHexString(value));
@@ -197,7 +213,8 @@ export const encrypt_address = (
     publicKey,
   );
   return {
-    data: encrypted.serialize(),
+    // insert security zone as first byte
+    data: new Uint8Array([securityZone, ...encrypted.serialize()]),
   };
 };
 /**
@@ -205,6 +222,7 @@ export const encrypt_address = (
  * @param {number} value - The numeric value to encrypt.
  * @param {TfheCompactPublicKey} publicKey - The public key used for encryption.
  * @param {EncryptionTypes} type - The encryption type (uint8, uint16, uint32).
+ * @param securityZone - The security zone to encrypt the value on.
  * @returns {Uint8Array} - The encrypted value serialized as Uint8Array.
  * @throws {Error} - Throws an error if an invalid type is specified.
  */
@@ -212,24 +230,25 @@ export const encrypt = (
   value: number,
   publicKey: TfheCompactPublicKey,
   type: EncryptionTypes = EncryptionTypes.uint8,
+  securityZone: number = 0,
 ): EncryptedNumber => {
   switch (type) {
     case EncryptionTypes.bool:
-      return encrypt_bool(!!value, publicKey);
+      return encrypt_bool(!!value, publicKey, securityZone);
     case EncryptionTypes.uint8:
-      return encrypt_uint8(value, publicKey);
+      return encrypt_uint8(value, publicKey, securityZone);
     case EncryptionTypes.uint16:
-      return encrypt_uint16(value, publicKey);
+      return encrypt_uint16(value, publicKey, securityZone);
     case EncryptionTypes.uint32:
-      return encrypt_uint32(value, publicKey);
+      return encrypt_uint32(value, publicKey, securityZone);
     case EncryptionTypes.uint64:
-      return encrypt_uint64(value.toString(16), publicKey);
+      return encrypt_uint64(value.toString(16), publicKey, securityZone);
     case EncryptionTypes.uint128:
-      return encrypt_uint128(value.toString(16), publicKey);
+      return encrypt_uint128(value.toString(16), publicKey, securityZone);
     case EncryptionTypes.uint256:
-      return encrypt_uint256(value.toString(16), publicKey);
+      return encrypt_uint256(value.toString(16), publicKey, securityZone);
     case EncryptionTypes.address:
-      return encrypt_address(value.toString(16), publicKey);
+      return encrypt_address(value.toString(16), publicKey, securityZone);
     default:
       throw new Error("Invalid type");
   }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -49,7 +49,7 @@ import {
 export class FhenixClient {
   private permits: ContractPermits = {};
   private defaultSecurityZone: number = 0;
-  public fhePublicKeys: Array<Promise<TfheCompactPublicKey | undefined>>;
+  public fhePublicKeys: Array<Promise<TfheCompactPublicKey | undefined>> = [];
   protected provider: SupportedProvider;
   /**
    * Creates an instance of FhenixClient.
@@ -71,7 +71,6 @@ export class FhenixClient {
     // case this should be called with initSdk = false (tests, for instance)
 
     /// #if DEBUG
-    this.fhePublicKeys = [];
     this.fhePublicKeys[this.defaultSecurityZone] = FhenixClient.getFheKeyFromProvider(this.provider).catch(
       (err) => {
         if (ignoreErrors) {
@@ -132,7 +131,6 @@ export class FhenixClient {
   private async _getPublicKey(securityZone: number) {
     let fhePublicKey = await this.fhePublicKeys[securityZone];
     if (!fhePublicKey) {
-      // try again to get the public key - maybe the 1st time the chain wasn't up or something
       this.fhePublicKeys[securityZone] = FhenixClient.getFheKeyFromProvider(this.provider, securityZone);
       fhePublicKey = await this.fhePublicKeys[securityZone];
       if (!fhePublicKey) {
@@ -245,10 +243,7 @@ export class FhenixClient {
 
     let outputSize = type;
 
-    const fhePublicKey = await this.fhePublicKeys[securityZone];
-    if (!fhePublicKey) {
-      throw new Error(`Public key for security zone ${securityZone} somehow not initialized`);
-    }
+    const fhePublicKey = await this._getPublicKey(securityZone);
 
     // choose the most efficient ciphertext size if not selected
     if (!outputSize) {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -111,7 +111,7 @@ export class FhenixClient {
    */
   async encrypt_bool(value: boolean, securityZone: number = 0): Promise<EncryptedBool> {
     const fhePublicKey = await this._getPublicKey(securityZone);
-    return tfheEncrypt.encrypt_bool(value, fhePublicKey);
+    return tfheEncrypt.encrypt_bool(value, fhePublicKey, securityZone);
   }
 
   /**
@@ -125,7 +125,7 @@ export class FhenixClient {
 
     const fhePublicKey = await this._getPublicKey(securityZone);
     ValidateUintInRange(value, MAX_UINT8, 0);
-    return tfheEncrypt.encrypt_uint8(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint8(value, fhePublicKey, securityZone);
   }
 
   private async _getPublicKey(securityZone: number) {
@@ -151,7 +151,7 @@ export class FhenixClient {
 
     const fhePublicKey = await this._getPublicKey(securityZone);
     ValidateUintInRange(value, MAX_UINT16, 0);
-    return tfheEncrypt.encrypt_uint16(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint16(value, fhePublicKey, securityZone);
   }
 
   /**
@@ -166,7 +166,7 @@ export class FhenixClient {
     const fhePublicKey = await this._getPublicKey(securityZone);
 
     ValidateUintInRange(value, MAX_UINT32, 0);
-    return tfheEncrypt.encrypt_uint32(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint32(value, fhePublicKey, securityZone);
   }
 
   /**
@@ -181,7 +181,7 @@ export class FhenixClient {
     const fhePublicKey = await this._getPublicKey(securityZone);
 
     // ValidateUintInRange(value, MAX_UINT64, 0);
-    return tfheEncrypt.encrypt_uint64(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint64(value, fhePublicKey, securityZone);
   }
 
   /**
@@ -196,7 +196,7 @@ export class FhenixClient {
     const fhePublicKey = await this._getPublicKey(securityZone);
 
     // ValidateUintInRange(value, MAX_UINT64, 0);
-    return tfheEncrypt.encrypt_uint128(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint128(value, fhePublicKey, securityZone);
   }
 
   /**
@@ -211,7 +211,7 @@ export class FhenixClient {
     const fhePublicKey = await this._getPublicKey(securityZone);
 
     // ValidateUintInRange(value, MAX_UINT64, 0);
-    return tfheEncrypt.encrypt_uint256(value, fhePublicKey);
+    return tfheEncrypt.encrypt_uint256(value, fhePublicKey, securityZone);
   }
   /**
    * Encrypts an Address (Uint160) value using the stored public key.
@@ -225,7 +225,7 @@ export class FhenixClient {
     const fhePublicKey = await this._getPublicKey(securityZone);
 
     // ValidateUintInRange(value, MAX_UINT64, 0);
-    return tfheEncrypt.encrypt_address(value, fhePublicKey);
+    return tfheEncrypt.encrypt_address(value, fhePublicKey, securityZone);
   }
   /**
    * Encrypts a numeric value according to the specified encryption type or the most efficient one based on the value.
@@ -271,7 +271,7 @@ export class FhenixClient {
       default:
     }
 
-    return tfheEncrypt.encrypt(value, fhePublicKey, type);
+    return tfheEncrypt.encrypt(value, fhePublicKey, type, securityZone);
   }
 
   // Unsealing Method

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -71,6 +71,7 @@ export class FhenixClient {
     // case this should be called with initSdk = false (tests, for instance)
 
     /// #if DEBUG
+    this.fhePublicKeys = [];
     this.fhePublicKeys[this.defaultSecurityZone] = FhenixClient.getFheKeyFromProvider(this.provider).catch(
       (err) => {
         if (ignoreErrors) {

--- a/test/instance.test.ts
+++ b/test/instance.test.ts
@@ -21,6 +21,7 @@ describe("token", () => {
   it("creates an instance", async () => {
     const provider = new MockProvider(tfhePublicKey);
     const instance = new FhenixClient({ provider, initSdk: false });
+    expect(instance.encrypt_bool).toBeDefined();
     expect(instance.encrypt_uint8).toBeDefined();
     expect(instance.encrypt_uint16).toBeDefined();
     expect(instance.encrypt_uint32).toBeDefined();
@@ -40,7 +41,7 @@ describe("token", () => {
     await provider.on("error", (_) => provider.destroy());
 
     await expect(
-      new FhenixClient({ provider, initSdk: false }).fhePublicKey,
+      new FhenixClient({ provider, initSdk: false }).fhePublicKeys,
     ).rejects.toThrow(/.*Error while requesting chainId from provider.*/i);
   });
 
@@ -53,7 +54,7 @@ describe("token", () => {
     Object.assign(provider, { send: undefined });
 
     await expect(
-      new FhenixClient({ provider, initSdk: false }).fhePublicKey,
+      new FhenixClient({ provider, initSdk: false }).fhePublicKeys,
     ).rejects.toThrow(
       "Received unsupported provider. 'send' or 'request' method not found",
     );
@@ -64,7 +65,7 @@ describe("token", () => {
       new FhenixClient({
         provider: new MockProvider(tfhePublicKey, "not a number"),
         initSdk: false,
-      }).fhePublicKey,
+      }).fhePublicKeys,
     ).rejects.toThrow(
       `received non-hex number from chainId request: "not a number"`,
     );
@@ -72,7 +73,7 @@ describe("token", () => {
     const secondProvider = new MockProvider(BigInt(10));
     await expect(
       new FhenixClient({ provider: secondProvider, initSdk: false })
-        .fhePublicKey,
+        .fhePublicKeys,
     ).rejects.toThrow("Error using publicKey from provider: expected string");
   });
 


### PR DESCRIPTION
Note: will probably not pass CI as it needs the new nitro for the new interface of getting the public key.

Lets users specify the security zone they want the number to be encrypted on.
e.g.
```
fhenixclient.encrypt_uint8(3, 1); // this specifies that the security zone is 1
```

Still didn't add tests here, but I did test this from the fheos repo
goes with fheos PR: https://github.com/FhenixProtocol/fheos/pull/115