### PR TITLE
Added types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The JavaScript SDK for Fhenix",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
+  "types": "./lib/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",


### PR DESCRIPTION
I suggest explicitly pointing to the types file in the `package.json` because the types file is not in the default location.

It should improve TypeScript support.

See [related TypeScript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html#editing-the-packagejson)