### PR TITLE
PermitV2 hardhat integration

### DIFF
--- a/src/sdk/v2/types.ts
+++ b/src/sdk/v2/types.ts
@@ -82,21 +82,21 @@ export type EncryptableAddress = {
 };
 
 export const Encryptable = {
-  bool: (data: EncryptableBool["data"], securityZone?: number) =>
+  bool: (data: EncryptableBool["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.bool }) as EncryptableBool,
-  uint8: (data: EncryptableUint8["data"], securityZone?: number) =>
+  uint8: (data: EncryptableUint8["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint8 }) as EncryptableUint8,
-  uint16: (data: EncryptableUint16["data"], securityZone?: number) =>
+  uint16: (data: EncryptableUint16["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint16 }) as EncryptableUint16,
-  uint32: (data: EncryptableUint32["data"], securityZone?: number) =>
+  uint32: (data: EncryptableUint32["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint32 }) as EncryptableUint32,
-  uint64: (data: EncryptableUint64["data"], securityZone?: number) =>
+  uint64: (data: EncryptableUint64["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint64 }) as EncryptableUint64,
-  uint128: (data: EncryptableUint128["data"], securityZone?: number) =>
+  uint128: (data: EncryptableUint128["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint128 }) as EncryptableUint128,
-  uint256: (data: EncryptableUint256["data"], securityZone?: number) =>
+  uint256: (data: EncryptableUint256["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.uint256 }) as EncryptableUint256,
-  address: (data: EncryptableAddress["data"], securityZone?: number) =>
+  address: (data: EncryptableAddress["data"], securityZone = 0) =>
     ({ data, securityZone, utype: FheUType.address }) as EncryptableAddress,
 } as const;
 
@@ -144,7 +144,7 @@ export function isEncryptableItem(value: any): value is EncryptableItem {
   return (
     typeof value === "object" &&
     value !== null &&
-    typeof value.data === "string" &&
+    ["string", "number", "bigint", "boolean"].includes(typeof value.data) &&
     typeof value.securityZone === "number" &&
     FheAllUTypes.includes(value.utype)
   );
@@ -372,6 +372,7 @@ export type PermitV2Options =
     >;
 
 export type SerializedPermitV2 = Omit<PermitV2Interface, "sealingPair"> & {
+  signedChainId: string | undefined;
   sealingPair: {
     privateKey: string;
     publicKey: string;


### PR DESCRIPTION
When interacting with the hardhat network (chainId 31337), there are a few changes:
- dont fetch fhePublicKeys
- dont use the fhePublicKey to encrypt incoming vars (`inEuint32` etc)
- dont use the user's permit `privateKey` to unseal outgoing vars (`SealedUint` etc)

Putting this in the new sdk means that we don't have to do this kind of overloading: https://github.com/FhenixProtocol/fhenix-hardhat-plugin/blob/master/packages/fhenix-hardhat-plugin/src/FhenixHardhatRuntimeEnvironment.ts

Also fixes a few bugs that showed up while working on `fhenix-hardhat-plugin`:
- default value of `securityZone` was `undefined`, now `0`
- `EncryptableItem` checking fixed
- removed `fhenixsdk.unseal(a, b, c)` pattern, instead use `fhenixsdk.unseal([a, b, c])`

