### PR TITLE
fix: `fhenixsdk` bugfixes

### DIFF
--- a/src/sdk/v2/permit.ts
+++ b/src/sdk/v2/permit.ts
@@ -4,7 +4,7 @@ import {
   AbstractSigner,
   isSealedAddress,
   isSealedBool,
-  isSealedItem,
+  getAsSealedItem,
   isSealedUint,
   MappedUnsealedTypes,
   PermissionV2,
@@ -387,20 +387,21 @@ export class PermitV2 implements PermitV2Interface, PermitV2Metadata {
   unseal<T extends any[]>(item: [...T]): [...MappedUnsealedTypes<T>];
   unseal<T>(item: T) {
     // SealedItem
-    if (isSealedItem(item)) {
+    const sealedItem = getAsSealedItem(item);
+    if (sealedItem != null) {
       const bn = chainIsHardhat(this._signedChainId)
-        ? hardhatMockUnseal(item.data)
-        : this.sealingPair.unseal(item.data);
+        ? hardhatMockUnseal(sealedItem.data)
+        : this.sealingPair.unseal(sealedItem.data);
 
-      if (isSealedBool(item)) {
+      if (isSealedBool(sealedItem)) {
         // Return a boolean for SealedBool
         return Boolean(bn).valueOf() as any;
       }
-      if (isSealedAddress(item)) {
+      if (isSealedAddress(sealedItem)) {
         // Return a string for SealedAddress
         return getAddress(`0x${bn.toString(16).slice(-40)}`) as any;
       }
-      if (isSealedUint(item)) {
+      if (isSealedUint(sealedItem)) {
         // Return a bigint for SealedUint
         return bn as any;
       }

--- a/src/sdk/v2/sdk.store.ts
+++ b/src/sdk/v2/sdk.store.ts
@@ -183,6 +183,12 @@ export const _store_initialize = async (params: InitParams) => {
   const account = await signer?.getAddress();
   if (account != null && signer != null) {
     _sdkStore.setState({ signerInitialized: true, account, signer });
+  } else {
+    _sdkStore.setState({
+      signerInitialized: false,
+      account: undefined,
+      signer: undefined,
+    });
   }
 
   // If chainId or securityZones changes, update the store and update fheKeys for re-initialization
@@ -226,23 +232,23 @@ export const _store_fetchFheKey = async (
   const funcSig = "0x1b1b484e"; // cast sig "getNetworkPublicKey(int32)"
   const callData = funcSig + toABIEncodedUint32(securityZone);
 
-  const publicKey = await provider
-    .call({ to: FheOpsAddress, data: callData })
-    .catch((err: Error) => {
-      throw Error(
-        `Error while requesting network public key from provider for security zone ${securityZone}: ${JSON.stringify(
-          err,
-        )}`,
-      );
-    });
+  const publicKey = await provider.call({ to: FheOpsAddress, data: callData });
 
   if (typeof publicKey !== "string") {
-    throw new Error("Error using publicKey from provider: expected string");
+    throw new Error(
+      "Error initializing fhenixjs; FHE publicKey fetched from provider invalid: not a string",
+    );
+  }
+
+  if (publicKey === "0x") {
+    throw new Error(
+      "Error initializing fhenixjs; provided chain is not FHE enabled, no FHE publicKey found",
+    );
   }
 
   if (publicKey.length < PUBLIC_KEY_LENGTH_MIN) {
     throw new Error(
-      `Error initializing fhenixjs; got shorter than expected public key: ${publicKey.length}`,
+      `Error initializing fhenixjs; got shorter than expected FHE publicKey: ${publicKey.length}. Expected length >= ${PUBLIC_KEY_LENGTH_MIN}`,
     );
   }
 

--- a/src/sdk/v2/types.ts
+++ b/src/sdk/v2/types.ts
@@ -180,45 +180,41 @@ export type MappedUnsealedTypes<T> = T extends Primitive
         [K in keyof T]: MappedUnsealedTypes<T[K]>;
       };
 
-// Type guard for any SealedItem
+// Determine if `value` is an instance of a `sealedItem` { data: string, utype: 0-5 | 12 | 13 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isSealedItem(value: any): value is SealedItem {
-  return (
+export function getAsSealedItem(value: any): SealedItem | undefined {
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === "string" &&
+    FheAllUTypes.includes(parseInt(`${value[1]}`))
+  )
+    return {
+      data: value[0],
+      utype: value[1],
+    };
+
+  if (
     typeof value === "object" &&
     value !== null &&
     typeof value.data === "string" &&
     FheAllUTypes.includes(value.utype)
-  );
+  )
+    return value as SealedItem;
+
+  return undefined;
 }
 
-// Type guard for SealedBool
-export function isSealedBool(value: SealedItem): value is SealedBool {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof value.data === "string" &&
-    value.utype === FheUType.bool
-  );
+export function isSealedBool(value: SealedItem): boolean {
+  return parseInt(`${value.utype}`) === FheUType.bool;
 }
 
-// Type guard for SealedUint
-export function isSealedUint(value: SealedItem): value is SealedUint {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof value.data === "string" &&
-    FheUintUTypes.includes(value.utype as number)
-  );
+export function isSealedUint(value: SealedItem): boolean {
+  return FheUintUTypes.includes(parseInt(`${value.utype}`));
 }
 
-// Type guard for SealedAddress
-export function isSealedAddress(value: SealedItem): value is SealedAddress {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof value.data === "string" &&
-    value.utype === FheUType.address
-  );
+export function isSealedAddress(value: SealedItem): boolean {
+  return parseInt(`${value.utype}`) === FheUType.address;
 }
 
 export type Result<T, E = string> =


### PR DESCRIPTION
I've been integrating the new `fhenixsdk` into `fhenix-hardhat-example` and have run into some rough edges. 
Bug Fixes / QoL improvements:
- ethers returns `SealedUint/Bool/Address` as an array `[data: string, utype: bigint]` instead of an object :: `unseal` can now handle the SealedOutput array types.
- `initializing` fhenixsdk should automatically create a default permit :: Generating a permit now happens automatically during `fhenixsdk.initialize`, but can be disabled with the param flag `generatePermit`.
- all return types have been made `Result`s (fixes `getPermission` inside of `encrypt` returning a `Result` object mismatch), all `fhenixsdk` functions updated to not throw errors (difficult to handle in a frontend reactive client)
- `encrypt` throws confusing error if not initialized :: `encrypt` and `encryptValue` now check to ensure that `fhenixsdk.initialize` has been called 

